### PR TITLE
feat: support for monocle offsets

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,17 +17,20 @@ struct Rule {
 struct Workspace {
     rules: Option<Vec<Rule>>,
     default: Option<Rect>,
+    monocle: Option<Rect>,
 }
 #[derive(Clone, Serialize, Deserialize, Debug)]
 struct Monitor {
     workspaces: Option<Vec<Workspace>>,
     rules: Option<Vec<Rule>>,
     default: Option<Rect>,
+    monocle: Option<Rect>,
 }
 #[derive(Clone, Serialize, Deserialize, Debug)]
 struct Config {
     monitors: Vec<Monitor>,
     default: Rect,
+    monocle: Option<Rect>,
 }
 #[derive(Clone, Debug)]
 struct AppState {
@@ -58,6 +61,7 @@ struct WorkspaceState {
     window_count: usize,
     rules: Option<Vec<Rule>>,
     default: Rect,
+    monocle: Option<Rect>,
 }
 
 const NAME: &str = "komofake.sock";
@@ -130,6 +134,12 @@ fn handle_state(state: State, app_state: &mut AppState) {
                 }
             }
         }
+        if workspace_state.monocle != None
+            && *monitor.focused_workspace().unwrap().monocle_container() != None
+        {
+            offset = workspace_state.monocle;
+        }
+
         if offset == None {
             offset = Some(workspace_state.default);
         }
@@ -152,32 +162,38 @@ fn update_offset(monitor_index: usize, offset: Rect) {
 fn initialize_app_state(config: &Config, state: &State) -> AppState {
     let mut app_state = AppState::new();
     let global_default = config.default;
+    let global_monocle = config.monocle;
     for (monitor_index, monitor) in state.monitors.elements().iter().enumerate() {
         let mut monitor_state = MonitorState::new();
         let focused_workspace_index = monitor.workspaces.focused_idx();
         app_state.active_workspace.push(focused_workspace_index);
         let monitor_default = config.monitors[monitor_index].default;
         let monitor_rules = &config.monitors[monitor_index].rules;
+        let monitor_monocle = config.monitors[monitor_index].monocle;
         for (workspace_index, workspace) in monitor.workspaces.elements().iter().enumerate() {
             let window_count = workspace.containers().len();
             let mut workspace_rules = None;
             let mut workspace_default: Option<Rect> = None;
+            let mut workspace_monocle = None;
 
             let monitor = &config.monitors[monitor_index];
             if let Some(workspaces) = &monitor.workspaces {
                 if let Some(workspace) = workspaces.get(workspace_index) {
                     workspace_default = workspace.default;
                     workspace_rules = workspace.rules.clone();
+                    workspace_monocle = workspace.monocle;
                 }
             }
             let default = workspace_default
                 .or(monitor_default)
                 .unwrap_or(global_default);
             let rules = workspace_rules.or(monitor_rules.clone());
+            let monocle = workspace_monocle.or(monitor_monocle).or(global_monocle);
             let workspace_state = WorkspaceState {
-                window_count: window_count,
-                rules: rules,
-                default: default,
+                window_count,
+                rules,
+                default,
+                monocle,
             };
             monitor_state.workspaces.push(workspace_state);
         }


### PR DESCRIPTION
Adds monocle support to workspaces, monitors and global.

Format:
```json
"monocle": {
    "top": 0,
    "right": 0,
    "bottom": 0,
    "left": 0
}
```